### PR TITLE
TC_001.23 Error message pops up if Password field is empty

### DIFF
--- a/autotests/marina_avr/test_001_23.py
+++ b/autotests/marina_avr/test_001_23.py
@@ -1,0 +1,28 @@
+import pytest
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from webdriver_manager.chrome import ChromeDriverManager
+
+BASE_URL = 'https://www.saucedemo.com'
+
+@pytest.fixture(scope='function')
+def browser():
+    print('\nstart browser...')
+    browser = webdriver.Chrome(ChromeDriverManager().install())
+    yield browser
+    print('\nquit browser...')
+    browser.quit()
+
+class TestLoginPage():
+
+    @pytest.mark.login
+    def test_password_empty_error(self, browser):
+        browser.get(BASE_URL)
+        username = browser.find_element(By.ID, 'user-name')
+        username.send_keys('standard_user')
+        button_login = browser.find_element(By.NAME, 'login-button').click()
+        error_locator = '//*[@id="login_button_container"]/div/form/div[3]/h3'
+        assert browser.find_element(By.XPATH, error_locator).text == 'Epic sadface: Password is required'
+
+
+


### PR DESCRIPTION
TC_001.23 Verify that 'Epic sadface: Password is required' error message pops up if the 'Password' field is empty.
test_001_23.py
[US] https://trello.com/c/6mfgeREk/57-us001-login-page
[TC] https://trello.com/c/XsDBfasw/135-tc00123-verify-that-epic-sadface-password-is-required-error-message-pops-up-if-the-password-field-is-empty
[AT] https://trello.com/c/0NI4lCnc/137-at00123-verify-that-epic-sadface-password-is-required-error-message-pops-up-if-the-password-field-is-empty
